### PR TITLE
Create Track Detail Page with Share Button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,11 +3,11 @@
 
 <head>
   <meta charset="utf-8" />
-  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <link rel="icon" href="%PUBLIC_URL%/power_music_logo-transparent.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="Web site created using create-react-app" />
-  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/power_music_logo-transparent.png" />
   <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route } from "react-router";
 import Navbar from "./Navbar";
 import Search from "./Search";
 import Home from "./Home";
+import TrackDetails from "./TrackDetails";
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
         <Container>
           <Routes>
             <Route path="/search" element={<Search />} />
+            <Route path="/tracks/:trackId" element={<TrackDetails />} />
             <Route path="/" element={<Home />} />
           </Routes>
         </Container>

--- a/src/App.js
+++ b/src/App.js
@@ -61,8 +61,14 @@ function App() {
         <Navbar />
         <Container>
           <Routes>
-            <Route path="/search" element={<Search />} />
-            <Route path="/tracks/:trackId" element={<TrackDetails />} />
+            <Route
+              path="/tracks/:trackId"
+              element={
+                <TrackDetails
+                  {...{ player, togglePlayer, queueTrackAndPlay }}
+                />
+              }
+            />
             <Route
               path="/search"
               element={

--- a/src/Navbar.jsx
+++ b/src/Navbar.jsx
@@ -13,17 +13,15 @@ const Navbar = () => {
   const getCurrentPathIndex = (currentPathValue) => {
     switch (currentPathValue) {
       case "/search":
-        return 1;
+        return 2;
       case "/":
-        return 0;
+        return 1;
       default:
-        return -1;
+        return 0;
     }
   };
 
-  const [value, setValue] = useState(() => {
-    return getCurrentPathIndex(currentPath);
-  });
+  const [value, setValue] = useState(getCurrentPathIndex(currentPath));
 
   useEffect(() => {
     setValue(getCurrentPathIndex(currentPath));

--- a/src/Navbar.jsx
+++ b/src/Navbar.jsx
@@ -64,7 +64,7 @@ const Navbar = () => {
         <BottomNavigationAction
           component={Link}
           to="/search"
-          label="Searches"
+          label="Search"
           icon={<SearchIcon />}
         />
       </BottomNavigation>

--- a/src/Navbar.jsx
+++ b/src/Navbar.jsx
@@ -14,8 +14,10 @@ const Navbar = () => {
     switch (currentPathValue) {
       case "/search":
         return 1;
-      default:
+      case "/":
         return 0;
+      default:
+        return -1;
     }
   };
 
@@ -30,7 +32,7 @@ const Navbar = () => {
   return (
     <Box
       sx={{
-        width: '100%',
+        width: "100%",
         margin: "0 auto",
         display: "flex",
         justifyContent: "center",
@@ -43,6 +45,18 @@ const Navbar = () => {
           setValue(newValue);
         }}
       >
+        <BottomNavigationAction
+          component={Link}
+          to="/"
+          icon={
+            <img
+              src="/power_music_logo-transparent.png"
+              alt="Power Music Logo"
+              width="50px"
+              height="50px"
+            />
+          }
+        />
         <BottomNavigationAction
           component={Link}
           to="/"

--- a/src/SearchResult.jsx
+++ b/src/SearchResult.jsx
@@ -11,9 +11,10 @@ const SearchResult = ({
 }) => {
   return (
     <TableRow>
-      {/* make first one a link to the song detail page */}
-      <TableCell>{searchResult.name}</TableCell>
-      {/* make second one a link to the artist detail page */}
+      <TableCell>
+        <a href={`/tracks/${searchResult.id}`}>{searchResult.name}</a>
+      </TableCell>
+      <TableCell>{searchResult.artist_name}</TableCell>
       <TableCell>{searchResult.artist_name}</TableCell>
       <TableCell>{searchResult.album_name}</TableCell>
       <TableCell>{searchResult.releasedate}</TableCell>

--- a/src/SearchResult.jsx
+++ b/src/SearchResult.jsx
@@ -18,7 +18,6 @@ const SearchResult = ({
         <a href={`/tracks/${searchResult.id}`}>{searchResult.name}</a>
       </TableCell>
       <TableCell>{searchResult.artist_name}</TableCell>
-      <TableCell>{searchResult.artist_name}</TableCell>
       <TableCell>{searchResult.album_name}</TableCell>
       <TableCell>{searchResult.releasedate}</TableCell>
       <TableCell align="center">

--- a/src/TrackDetails.jsx
+++ b/src/TrackDetails.jsx
@@ -5,6 +5,7 @@ import {
   List,
   ListItem,
   ListItemText,
+  Skeleton,
 } from "@mui/material";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router";
@@ -33,6 +34,39 @@ const TrackDetails = () => {
     <Container>
       {track === undefined ? (
         <h2>Track Not Found!</h2>
+      ) : !track.name ? (
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: { xs: "column", md: "row" },
+            margin: "3em",
+            gap: 2,
+          }}
+        >
+          <Skeleton
+            variant="rectangular"
+            sx={imageStyle}
+            height={300}
+            animation="pulsate"
+          />
+          <Box sx={{ width: { xs: "100%", md: "50%" } }}>
+            <Skeleton
+              variant="text"
+              sx={{ fontSize: "2rem", mb: 2 }}
+              animation="pulsate"
+            />
+            <List>
+              {[...Array(4)].map((_, index) => (
+                <ListItem key={index}>
+                  <ListItemText
+                    primary={<Skeleton width="20%" animation="pulsate" />}
+                    secondary={<Skeleton width="60%" animation="pulsate" />}
+                  />
+                </ListItem>
+              ))}
+            </List>
+          </Box>
+        </Box>
       ) : (
         <Box
           sx={{

--- a/src/TrackDetails.jsx
+++ b/src/TrackDetails.jsx
@@ -6,7 +6,11 @@ import {
   ListItem,
   ListItemText,
   Skeleton,
+  Button,
+  Menu,
+  MenuItem,
 } from "@mui/material";
+import { Share } from "@mui/icons-material";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router";
 import PreviewButton from "./PreviewButton";
@@ -29,6 +33,15 @@ const TrackDetails = ({ player, togglePlayer, queueTrackAndPlay }) => {
     width: "100%",
     height: "auto",
     maxWidth: { xs: "100%", md: "50%" },
+  };
+
+  const [anchorEl, setAnchorEl] = useState(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
   };
 
   return (
@@ -79,11 +92,11 @@ const TrackDetails = ({ player, togglePlayer, queueTrackAndPlay }) => {
         >
           <Box
             sx={{
-              position: 'relative',
+              position: "relative",
               width: { xs: "100%", md: "50%" },
-              '&:hover .hover-content': {
-                opacity: 1
-              }
+              "&:hover .hover-content": {
+                opacity: 1,
+              },
             }}
           >
             <Box
@@ -92,7 +105,7 @@ const TrackDetails = ({ player, togglePlayer, queueTrackAndPlay }) => {
                 width: "100%",
                 height: "100%",
                 objectFit: "cover",
-                display: "block"
+                display: "block",
               }}
               alt="Track artwork"
               src={track.album_image}
@@ -100,15 +113,14 @@ const TrackDetails = ({ player, togglePlayer, queueTrackAndPlay }) => {
             <Box
               className="hover-content"
               sx={{
-                position: 'absolute',
-                top: '50%',
-                left: '50%',
-                transform: 'translate(-50%, -50%)',
+                position: "absolute",
+                top: "50%",
+                left: "50%",
+                transform: "translate(-50%, -50%)",
                 opacity: 0,
-                transition: 'opacity 0.3s ease',
-                backgroundColor: 'rgba(0,0,0,0.7)',
+                transition: "opacity 0.2s ease",
+                backgroundColor: "rgba(255, 255, 255, 0.27)",
                 padding: 2,
-                borderRadius: 1
               }}
             >
               <PreviewButton
@@ -122,6 +134,45 @@ const TrackDetails = ({ player, togglePlayer, queueTrackAndPlay }) => {
           <Box sx={{ width: { xs: "100%", md: "50%" } }}>
             <Typography variant="h4" gutterBottom>
               {track.name}
+              <div>
+                <Button
+                  id="basic-button"
+                  aria-controls={open ? "basic-menu" : undefined}
+                  aria-haspopup="true"
+                  aria-expanded={open ? "true" : undefined}
+                  onClick={handleClick}
+                  variant="contained"
+                >
+                  Share <Share />
+                </Button>
+                <Menu
+                  id="basic-menu"
+                  anchorEl={anchorEl}
+                  open={open}
+                  onClose={handleClose}
+                  slotProps={{
+                    list: {
+                      "aria-labelledby": "basic-button",
+                    },
+                  }}
+                >
+                  <MenuItem
+                    onClick={() => {
+                      const trackUrl = track.shareurl;
+                      navigator.clipboard
+                        .writeText(trackUrl)
+                        .then(() => {
+                          setAnchorEl(null);
+                        })
+                        .catch((err) => {
+                          console.error("Failed to copy: ", err);
+                        });
+                    }}
+                  >
+                    Copy Link
+                  </MenuItem>
+                </Menu>
+              </div>
             </Typography>
             <List>
               <ListItem>

--- a/src/TrackDetails.jsx
+++ b/src/TrackDetails.jsx
@@ -9,8 +9,9 @@ import {
 } from "@mui/material";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router";
+import PreviewButton from "./PreviewButton";
 
-const TrackDetails = () => {
+const TrackDetails = ({ player, togglePlayer, queueTrackAndPlay }) => {
   const [track, setTrack] = useState({});
   const { trackId } = useParams();
 
@@ -77,11 +78,47 @@ const TrackDetails = () => {
           }}
         >
           <Box
-            component="img"
-            sx={imageStyle}
-            alt="Track artwork"
-            src={track.album_image}
-          />
+            sx={{
+              position: 'relative',
+              width: { xs: "100%", md: "50%" },
+              '&:hover .hover-content': {
+                opacity: 1
+              }
+            }}
+          >
+            <Box
+              component="img"
+              sx={{
+                width: "100%",
+                height: "100%",
+                objectFit: "cover",
+                display: "block"
+              }}
+              alt="Track artwork"
+              src={track.album_image}
+            />
+            <Box
+              className="hover-content"
+              sx={{
+                position: 'absolute',
+                top: '50%',
+                left: '50%',
+                transform: 'translate(-50%, -50%)',
+                opacity: 0,
+                transition: 'opacity 0.3s ease',
+                backgroundColor: 'rgba(0,0,0,0.7)',
+                padding: 2,
+                borderRadius: 1
+              }}
+            >
+              <PreviewButton
+                track={track}
+                player={player}
+                togglePlayer={togglePlayer}
+                queueTrackAndPlay={queueTrackAndPlay}
+              />
+            </Box>
+          </Box>
           <Box sx={{ width: { xs: "100%", md: "50%" } }}>
             <Typography variant="h4" gutterBottom>
               {track.name}

--- a/src/TrackDetails.jsx
+++ b/src/TrackDetails.jsx
@@ -1,0 +1,79 @@
+import {
+  Container,
+  Box,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+} from "@mui/material";
+import { useEffect, useState } from "react";
+import { useParams } from "react-router";
+
+const TrackDetails = () => {
+  const [track, setTrack] = useState({});
+  const { trackId } = useParams();
+
+  useEffect(() => {
+    if (trackId) {
+      fetch(
+        `https://api.jamendo.com/v3.0/tracks/?client_id=${process.env.REACT_APP_API_ID}&format=jsonpretty&limit=1&id=${trackId}`,
+      )
+        .then((response) => response.json())
+        .then((data) => setTrack(data.results[0]))
+        .catch((error) => console.error("Error fetching track:", error));
+    }
+  }, []);
+  const imageStyle = {
+    width: "100%",
+    height: "auto",
+    maxWidth: { xs: "100%", md: "50%" },
+  };
+
+  return (
+    <Container>
+      {track === undefined ? (
+        <h2>Track Not Found!</h2>
+      ) : (
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: { xs: "column", md: "row" },
+            margin: "3em",
+            gap: 2,
+          }}
+        >
+          <Box
+            component="img"
+            sx={imageStyle}
+            alt="Track artwork"
+            src={track.album_image}
+          />
+          <Box sx={{ width: { xs: "100%", md: "50%" } }}>
+            <Typography variant="h4" gutterBottom>
+              {track.name}
+            </Typography>
+            <List>
+              <ListItem>
+                <ListItemText primary="Artist" secondary={track.artist_name} />
+              </ListItem>
+              <ListItem>
+                <ListItemText primary="Album" secondary={track.album_name} />
+              </ListItem>
+              <ListItem>
+                <ListItemText
+                  primary="Release Date"
+                  secondary={track.releasedate}
+                />
+              </ListItem>
+              <ListItem>
+                <ListItemText primary="Duration" secondary={track.duration} />
+              </ListItem>
+            </List>
+          </Box>
+        </Box>
+      )}
+    </Container>
+  );
+};
+
+export default TrackDetails;


### PR DESCRIPTION
This pull request introduces a new `TrackDetails` page to display detailed information about individual tracks, updates navigation and styling in the `Navbar`, and enhances the search results to link to the new page. Additionally, it replaces the favicon and logo across the application. Below is a breakdown of the most important changes:

### New `TrackDetails` Page:
* Added `TrackDetails` component to display detailed track information, including artwork, artist, album, release date, duration, and a share button. The page fetches data from the Jamendo API based on the track ID in the URL.
* Integrated a `PreviewButton` for track playback and implemented a clipboard copy feature for sharing track links.

### Navigation Updates:
* Updated `App.js` to include a new route for the `TrackDetails` page at `/tracks/:trackId`.
* Modified `Navbar.jsx` to include a navigation button linking to the homepage with a logo icon and adjusted the label for the search button. [[1]](diffhunk://#diff-18145057f4ffcc07ef023a2aa46b82b8f14a15d3a818b621a3bb7644281407a1R46-R57) [[2]](diffhunk://#diff-18145057f4ffcc07ef023a2aa46b82b8f14a15d3a818b621a3bb7644281407a1L55-R67)

### Search Results Enhancement:
* Updated `SearchResult.jsx` to make track names clickable, linking to their respective `TrackDetails` pages.

### Styling and Asset Updates:
* Replaced the favicon and Apple Touch Icon with a new logo file (`power_music_logo-transparent.png`) in `public/index.html`.
* Adjusted minor formatting in `Navbar.jsx` for consistency (e.g., replacing single quotes with double quotes).