### PR TITLE
Show Top Tracks on Home Page

### DIFF
--- a/db.json
+++ b/db.json
@@ -51,6 +51,19 @@
       "audio": "https://prod-1.storage.jamendo.com/?trackid=2225331&format=mp31&from=Cdo8DQ1XpHABAInvciJE8Q%3D%3D%7Cuyf%2FhOyS%2F%2B2aVswU2PBf1A%3D%3D",
       "shareurl": "https://www.jamendo.com/track/2225331",
       "image": "https://usercontent.jamendo.com?type=album&id=590569&width=300&trackid=2225331"
+    },
+    {
+      "id": "7ac5",
+      "track_id": "246560",
+      "name": "I Don't Wanna Be",
+      "duration": 200,
+      "artist_name": "Ades Vapor",
+      "album_name": "Get High EP (Re-Edit)",
+      "releasedate": "2008-11-28",
+      "album_image": "https://usercontent.jamendo.com?type=album&id=35657&width=300&trackid=246560",
+      "audio": "https://prod-1.storage.jamendo.com/?trackid=246560&format=mp31&from=EwhT1XKmgT1U0bMIXU6nfg%3D%3D%7CmX4fA7irfl1u7Umbsk134Q%3D%3D",
+      "shareurl": "https://www.jamendo.com/track/246560",
+      "image": "https://usercontent.jamendo.com?type=album&id=35657&width=300&trackid=246560"
     }
   ]
 }

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ function App() {
     isPlaying: false,
   });
   const [shouldPlay, setShouldPlay] = useState(false);
-  const favoriteUrl = "http://localhost:3001/favorites/";
+  const favoriteUrl = process.env.REACT_APP_DB_URL + "favorites/";
   const [favorites, setFavorites] = useState([]);
   const isTrackInFavorites = (track) => {
     return favorites.find(

--- a/src/Home.jsx
+++ b/src/Home.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import SearchResults from "./SearchResults";
+import TrackImageGallery from "./TrackImageGallery";
 
 const Home = ({
   player,
@@ -12,7 +12,7 @@ const Home = ({
   const [topTracks, setTopTracks] = useState([]);
   useEffect(() => {
     fetch(
-      `https://api.jamendo.com/v3.0/tracks/?client_id=${process.env.REACT_APP_API_ID}&format=json&limit=10&fullcount=true&order=listens_week_desc`,
+      `https://api.jamendo.com/v3.0/tracks/?client_id=${process.env.REACT_APP_API_ID}&format=json&limit=9&fullcount=true&order=listens_week_desc`,
     )
       .then((r) => r.json())
       .then((response) => setTopTracks(response.results || []));
@@ -25,16 +25,16 @@ const Home = ({
         search feature to find popular independent music!
       </p>
       <hr />
-      <SearchResults
+      <h2>This Week's Top Tracks</h2>
+      <TrackImageGallery
         {...{
-          searchResults: topTracks,
+          topTracks,
           favorites,
           onFavoriteButtonClick,
           isTrackInFavorites,
           player,
           togglePlayer,
           queueTrackAndPlay,
-          tableTitle: "This Week's Top Hits",
         }}
       />
     </div>

--- a/src/TrackImageGallery.jsx
+++ b/src/TrackImageGallery.jsx
@@ -1,0 +1,55 @@
+import ImageList from "@mui/material/ImageList";
+import ImageListItem from "@mui/material/ImageListItem";
+import ImageListItemBar from "@mui/material/ImageListItemBar";
+import IconButton from "@mui/material/IconButton";
+import PreviewButton from "./PreviewButton";
+import FavoriteButton from "./FavoriteButton";
+
+const TrackImageGallery = ({
+  topTracks,
+  favorites,
+  onFavoriteButtonClick,
+  isTrackInFavorites,
+  player,
+  togglePlayer,
+  queueTrackAndPlay,
+}) => {
+  return (
+    <ImageList sx={{ width: "100%", height: "100%" }} cols={3}>
+      {topTracks.map((track) => (
+        <ImageListItem key={track.id}>
+          <img
+            srcSet={`${track.album_image}`}
+            src={`${track.album_image}`}
+            alt={track.name}
+            loading="lazy"
+          />
+          <ImageListItemBar
+            title={track.name}
+            subtitle={track.artist_name}
+            actionIcon={
+              <IconButton
+                sx={{ color: "rgba(255, 255, 255, 0.54)" }}
+                aria-label={`info about ${track.name}`}
+              >
+                <PreviewButton
+                  {...{ track, player, togglePlayer, queueTrackAndPlay }}
+                />
+                <FavoriteButton
+                  {...{
+                    track,
+                    favorites,
+                    onFavoriteButtonClick,
+                    isTrackInFavorites,
+                  }}
+                />
+              </IconButton>
+            }
+          />
+        </ImageListItem>
+      ))}
+    </ImageList>
+  );
+};
+
+export default TrackImageGallery;


### PR DESCRIPTION
This pull request introduces significant updates to enhance the application's functionality and user experience. Key changes include dynamic environment-based configuration for API URLs and the implementation of a gallery component to display top tracks. These updates improve the application's responsiveness and usability while integrating new features.

<img width="1210" alt="Screenshot 2025-07-02 at 13 02 47" src="https://github.com/user-attachments/assets/9eed1dfa-8192-41ae-9582-b24bf02d3014" />

### Environment Configuration:
* Updated the `favoriteUrl` in `src/App.js` to use the `REACT_APP_DB_URL` environment variable for dynamic configuration, enhancing flexibility for different deployment environments.

### Home Page Enhancements:
* Refactored the `Home` component in `src/Home.jsx` to fetch and display top tracks from the Jamendo API. Added support for passing player and favorites-related props to the component, enabling interaction with tracks directly from the home page.
* Modified the route definition in `src/App.js` to pass player-related and favorites-related props to the `Home` component, ensuring seamless integration of the new features.

### New Component Implementation:
* Introduced the `TrackImageGallery` component in `src/TrackImageGallery.jsx` to display top tracks in a responsive image gallery. Integrated preview and favorite buttons for each track, allowing users to interact with tracks directly from the gallery.